### PR TITLE
Update quickstart.adoc

### DIFF
--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -157,7 +157,7 @@ class AService {
     @Autowired
     HelloClient client;
 
-	public String hello() throws IOException {
+	public Mono<String> hello() throws IOException {
 		return client.hello();
 	}
 }


### PR DESCRIPTION
Fix the return type is Mono<String>