### PR TITLE
Use a custom conversion service

### DIFF
--- a/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/square/retrofit/DefaultRetrofitClientConfiguration.java
+++ b/spring-cloud-square-retrofit/src/main/java/org/springframework/cloud/square/retrofit/DefaultRetrofitClientConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.square.retrofit.support.SpringConverterFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.Qualifier;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.ConverterFactory;
 import org.springframework.format.support.DefaultFormattingConversionService;
@@ -59,7 +60,6 @@ public class DefaultRetrofitClientConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(ConversionService.class)
 	public DefaultFormattingConversionService retrofitConversionService() {
 		return new DefaultFormattingConversionService();
 	}
@@ -67,7 +67,7 @@ public class DefaultRetrofitClientConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(ConverterFactory.class)
 	public SpringConverterFactory springConverterFactory(ObjectFactory<HttpMessageConverters> messageConverters,
-			ConversionService conversionService) {
+			@Qualifier("retrofitConversionService") ConversionService conversionService) {
 		return new SpringConverterFactory(messageConverters, conversionService);
 	}
 


### PR DESCRIPTION
You can have multiple conversion services on the classpath, with the current setup it will lead to context not starting. Try generating a project with Square & Spring Cloud Stream on the classpath and you'll get the following

```
2022-02-13 14:49:22.134 ERROR 55883 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 1 of method springConverterFactory in org.springframework.cloud.square.retrofit.DefaultRetrofitClientConfiguration required a single bean, but 2 were found:
	- mvcConversionService: defined by method 'mvcConversionService' in class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]
	- integrationConversionService: defined in null


Action:

Consider marking one of the beans as @Primary, updating the consumer to accept multiple beans, or using @Qualifier to identify the bean that should be consumed

```